### PR TITLE
Upgrade to SilverStripe 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,16 @@
         }
     ],
     "require": {
-        "silvershop/silverstripe-hasonefield": "^4.0",
-        "silverstripe/linkfield": "^4.0",
-        "silverstripe/recipe-cms": "^5",
-        "symbiote/silverstripe-gridfieldextensions": "^4",
-        "unclecheese/display-logic": "^3.0"
+        "php": "^8.3 || ^8.4",
+        "silvershop/silverstripe-hasonefield": "^5.0",
+        "silverstripe/linkfield": "^5.0",
+        "silverstripe/recipe-cms": "^6",
+        "symbiote/silverstripe-gridfieldextensions": "^5",
+        "unclecheese/display-logic": "^4.0"
     },
     "require-dev": {
-        "dnadesign/silverstripe-elemental": "^5",
-        "silverstripe/recipe-testing": "^3.0"
+        "dnadesign/silverstripe-elemental": "^6",
+        "silverstripe/recipe-testing": "^4.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -43,7 +44,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.x-dev"
+            "dev-master": "4.x-dev",
+            "dev-5.0/ss6-upgrade": "5.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.x-dev",
             "dev-5.0/ss6-upgrade": "5.0.x-dev"
         }
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+  level: 4
+  treatPhpDocTypesAsCertain: false
+  paths:
+    - src
+  ignoreErrors:
+    # SilverStripe specific ignores can be added here if needed

--- a/src/Extension/BlogDataExtension.php
+++ b/src/Extension/BlogDataExtension.php
@@ -5,7 +5,7 @@ namespace Dynamic\SiteTools\Extension;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\ORM\ArrayList;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 use SilverStripe\ORM\PaginatedList;
 
 /**
@@ -13,7 +13,7 @@ use SilverStripe\ORM\PaginatedList;
  *
  * @property BlogDataExtension $owner
  */
-class BlogDataExtension extends DataExtension
+class BlogDataExtension extends Extension
 {
     /**
      * @param $tags

--- a/src/Extension/BlogPostDataExtension.php
+++ b/src/Extension/BlogPostDataExtension.php
@@ -9,7 +9,7 @@ use SilverStripe\Control\Director;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\ArrayList;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\ORM\PaginatedList;
@@ -20,7 +20,7 @@ use SilverStripe\ORM\PaginatedList;
  * @property BlogPostDataExtension $owner
  * @property string $SubTitle
  */
-class BlogPostDataExtension extends DataExtension
+class BlogPostDataExtension extends Extension
 {
     /**
      * @var array

--- a/src/Extension/ContactDataExtension.php
+++ b/src/Extension/ContactDataExtension.php
@@ -6,7 +6,7 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\EmailField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 
 /**
  * Class ContactDataExtension
@@ -17,7 +17,7 @@ use SilverStripe\ORM\DataExtension;
  * @property string $Fax
  * @property string $Email
  */
-class ContactDataExtension extends DataExtension
+class ContactDataExtension extends Extension
 {
     /**
      * @var array

--- a/src/Extension/DataobjectPermissionExtension.php
+++ b/src/Extension/DataobjectPermissionExtension.php
@@ -2,14 +2,14 @@
 
 namespace Dynamic\SiteTools\Extension;
 
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 
 /**
  * Class DataobjectPermissionExtension.
  *
  * @property EditableCustomRule|EditableFormField|DataobjectPermissionExtension $owner
  */
-class DataobjectPermissionExtension extends DataExtension
+class DataobjectPermissionExtension extends Extension
 {
     /**
      * @param null $member

--- a/src/Extension/ElementListLayoutExtension.php
+++ b/src/Extension/ElementListLayoutExtension.php
@@ -4,7 +4,7 @@ namespace Dynamic\SiteTools\Extension;
 
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 
 /**
  * Class ElementListLayoutExtension
@@ -12,7 +12,7 @@ use SilverStripe\ORM\DataExtension;
  * @property ElementListLayoutExtension $owner
  * @property string $Columns
  */
-class ElementListLayoutExtension extends DataExtension
+class ElementListLayoutExtension extends Extension
 {
     /**
      * @var array

--- a/src/Extension/HeaderImageExtension.php
+++ b/src/Extension/HeaderImageExtension.php
@@ -7,7 +7,7 @@ use Dynamic\Base\Page\BlockPage;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\HiddenField;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 use SilverStripe\Forms\LiteralField;
 use Dynamic\SiteTools\Model\HeaderImage;
 use Dynamic\Base\Page\CampaignLandingPage;
@@ -21,7 +21,7 @@ use SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter;
  * @property int $HeaderImageID
  * @method HeaderImage HeaderImage()
  */
-class HeaderImageExtension extends DataExtension
+class HeaderImageExtension extends Extension
 {
     /**
      * @var array

--- a/src/Extension/PreviewExtension.php
+++ b/src/Extension/PreviewExtension.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\SiteTools\Extension;
 
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\HTMLEditor\HtmlEditorField;
@@ -19,7 +19,7 @@ use SilverStripe\Assets\Image;
  * @property int $PreviewImageID
  * @method Image PreviewImage()
  */
-class PreviewExtension extends DataExtension
+class PreviewExtension extends Extension
 {
     /**
      * @var array

--- a/src/Extension/ReviewContentDataExtension.php
+++ b/src/Extension/ReviewContentDataExtension.php
@@ -4,7 +4,7 @@ namespace Dynamic\SiteTools\Extension;
 
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 
 /**
  * Class ReviewContentDataExtension
@@ -12,7 +12,7 @@ use SilverStripe\ORM\DataExtension;
  * @property SiteConfig|ReviewContentDataExtension $owner
  * @property bool $ReviewContent
  */
-class ReviewContentDataExtension extends DataExtension
+class ReviewContentDataExtension extends Extension
 {
     /**
      * @var array


### PR DESCRIPTION
## Overview
Upgrades the module to support SilverStripe CMS 6.

## Changes
- Add PHP requirement `^8.3 || ^8.4` (SS6 requires PHP 8.3+)
- Update `silvershop/silverstripe-hasonefield` to `^5.0`
- Update `silverstripe/linkfield` to `^5.0`
- Update `silverstripe/recipe-cms` to `^6`
- Update `symbiote/silverstripe-gridfieldextensions` to `^5`
- Update `unclecheese/display-logic` to `^4.0`
- Update `dnadesign/silverstripe-elemental` to `^6` (dev dependency)
- Update `silverstripe/recipe-testing` to `^4.0`
- Add branch-alias for `5.0.x-dev`

## Dependencies
All third-party dependencies have SS6-compatible versions available.

## Testing
- [ ] Verify all site tools functionality
- [ ] Test HasOneField integration
- [ ] Test GridFieldExtensions compatibility
- [ ] Test with SS6 CMS admin

## Related
- Part of the SS6 upgrade effort for Dynamic modules
- Required by `dynamic/silverstripe-base-site` PR #160