### PR TITLE
Update README for version 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,18 @@
 
 Tools to build common functionality in SilverStripe sites.
 
-[![CI](https://github.com/dynamic/silverstripe-site-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-site-tools/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/dynamic/silverstripe-site-tools/branch/master/graph/badge.svg)](https://codecov.io/gh/dynamic/silverstripe-site-tools)
+[![CI](https://github.com/dynamic/silverstripe-site-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-site-tools/actions/workflows/ci.yml) [![GitHub Sponsors](https://img.shields.io/github/sponsors/dynamic)](https://github.com/sponsors/dynamic)
 
-[![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-site-tools/v/stable)](https://packagist.org/packages/dynamic/silverstripe-site-tools)
-[![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-site-tools/downloads)](https://packagist.org/packages/dynamic/silverstripe-site-tools)
-[![Latest Unstable Version](https://poser.pugx.org/dynamic/silverstripe-site-tools/v/unstable)](https://packagist.org/packages/dynamic/silverstripe-site-tools)
-[![License](https://poser.pugx.org/dynamic/silverstripe-site-tools/license)](https://packagist.org/packages/dynamic/silverstripe-site-tools)
+[![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-site-tools/v/stable)](https://packagist.org/packages/dynamic/silverstripe-site-tools) [![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-site-tools/downloads)](https://packagist.org/packages/dynamic/silverstripe-site-tools) [![Latest Unstable Version](https://poser.pugx.org/dynamic/silverstripe-site-tools/v/unstable)](https://packagist.org/packages/dynamic/silverstripe-site-tools) [![License](https://poser.pugx.org/dynamic/silverstripe-site-tools/license)](https://packagist.org/packages/dynamic/silverstripe-site-tools)
 
 
 ## Requirements
 
-* Silverstripe ^5
-* silvershop/silverstripe-hasonefield ^4
-* silverstripe/linkfield: ^4
-* symbiote/silverstripe-gridfieldextensions ^4
-* unclecheese/display-logic ^3
+* Silverstripe ^6
+* silvershop/silverstripe-hasonefield ^5
+* silverstripe/linkfield ^5
+* symbiote/silverstripe-gridfieldextensions ^5
+* unclecheese/display-logic ^4
 
 ## Installation
 
@@ -28,9 +24,17 @@ composer require dynamic/silverstripe-site-tools
 ## License
 See [License](license.md)
 
+## Upgrading from version 4
+
+SilverStripe Site Tools 5.0 is compatible with SilverStripe 6. Key changes:
+
+- Updated to SilverStripe CMS 6
+- Requires PHP 8.1 or higher
+- Updated all major dependencies to their SS6-compatible versions
+
 ## Upgrading from version 3
 
-This module drops `gorriecoe/silverstripe-linkfield` usage in favor of `silverstripe/linkfield`.
+Version 4 dropped `gorriecoe/silverstripe-linkfield` usage in favor of `silverstripe/linkfield`.
 
 ## Maintainers
  *  [Dynamic](http://www.dynamicagency.com) (<dev@dynamicagency.com>)


### PR DESCRIPTION
Updates the README to reflect SilverStripe 6 compatibility for version 5.0.

## Changes

- Update requirements to SilverStripe 6 versions
- Add upgrade notes from version 4 to 5
- Remove codecov badge (no longer in use)
- Add GitHub Sponsors badge
- Reorganize badges for better readability (GitHub badges on one line, Packagist badges on another)

This prepares the documentation for the 5.0.0 release.