### PR TITLE
fix: SS6 namespace move — PaginatedList

### DIFF
--- a/src/Extension/BlogDataExtension.php
+++ b/src/Extension/BlogDataExtension.php
@@ -6,7 +6,7 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Model\List\ArrayList;
 use SilverStripe\Core\Extension;
-use SilverStripe\ORM\PaginatedList;
+use SilverStripe\Model\List\PaginatedList;
 
 /**
  * Class \Dynamic\SiteTools\Extension\BlogDataExtension

--- a/src/Extension/BlogPostDataExtension.php
+++ b/src/Extension/BlogPostDataExtension.php
@@ -12,7 +12,7 @@ use SilverStripe\Model\List\ArrayList;
 use SilverStripe\Core\Extension;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\FieldType\DBHTMLText;
-use SilverStripe\ORM\PaginatedList;
+use SilverStripe\Model\List\PaginatedList;
 
 /**
  * Class BlogPostDataExtension


### PR DESCRIPTION
## Summary
- `SilverStripe\ORM\PaginatedList` → `SilverStripe\Model\List\PaginatedList` (BlogDataExtension, BlogPostDataExtension)

Class moved in SilverStripe 6. Caught by PHPStan audit across the full Essentials suite.

## Test plan
- [ ] `ddev sake dev/build flush=1` passes (verified in testbed)
- [ ] PHPStan reports no errors on these files